### PR TITLE
Track player's view area on server on Update event

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -1,0 +1,27 @@
+name: Rust Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Run Rust Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -399,6 +399,39 @@ impl GameState {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_handle_update_action_updates_visible_area() {
+        let mut game_state = GameState::new();
+
+        // Add a player
+        let join_action = PlayerAction::Join {
+            visible_area: ((0, 0), (10, 10)),
+            token: None,
+        };
+        let join_response = game_state.process_action(None, join_action);
+
+        let player_id = match join_response {
+            GameStateResponse::Joined { player_id, .. } => player_id,
+            _ => panic!("Expected Joined response"),
+        };
+
+        // Update the player's visible area
+        let new_area = ((5, 5), (15, 15));
+        let update_action = PlayerAction::Update {
+            area_to_update: new_area,
+        };
+        game_state.process_action(Some(player_id), update_action);
+
+        // Check if the player's visible area was updated
+        let updated_player = game_state.players.get(&player_id).unwrap();
+        assert_eq!(updated_player.visible_area, new_area, "Player's visible area should be updated");
+    }
+}
+
 // iterate over all tiles around a position, but not the tile itself
 fn tiles_around(position: Position) -> impl Iterator<Item=Position> {
     (-1..=1).flat_map(move |dx|

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ async fn handle_connection(ws: warp::ws::WebSocket, game_state: Arc<Mutex<GameSt
             if let Ok(text) = message.to_str() {
                 let action: PlayerAction = serde_json::from_str(text).unwrap();
                 let mut game_state = game_state.lock().await;
-                let response = game_state.process_action(action.clone());
+                let response = game_state.process_action(player_id, action.clone());
 
                 if player_id.is_none() {
                     if let PlayerAction::Join { .. } = action {


### PR DESCRIPTION
Fixes #16

Description originally written by [Aider](https://aider.chat/) and refined by @akaihola:

### 1. Player Action Handling

- Modified `process_action` in `GameState` to accept an optional `player_id`:
  - This allows to pass the original assigned `player_id` to the `Update` action handler.
  - See also #19

### 2. Update Action Handling

- Enhanced `handle_update_action` to update the player's visible area:
  - Now takes `player_id` as a parameter.
  - Updates the player's visible area in the game state.
  - Returns an error if the player is not found.
  - This is the part that actually fixes #16

### 3. WebSocket Connection Handling

- Updated `handle_connection` in `main.rs`:
  - Now passes `player_id` to `process_action`.
  - Allows using the original assigned player ID in action handlers.

## Benefits

- Fixes #16: tile updates are now always broadcast to other players who should have visibility to them
- Better error handling and validation for player actions.
- More robust player identification in action processing.

## Testing

- Added a new unit test `test_handle_update_action_updates_visible_area` to verify the correct updating of a player's visible area.
