### PR TITLE
Prevent duplicate entries on the leaderboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- See https://medium.com/dailyjs/running-mocha-tests-as-native-es6-modules-in-a-browser-882373f2ecb0 -->
 <html lang="en">
 <head>
     <meta charset="UTF-8">

--- a/public/leaderboard.mjs
+++ b/public/leaderboard.mjs
@@ -3,53 +3,60 @@ import {log} from "./utils.mjs";
 import {safeSend} from './net/websocket.mjs';
 
 
-// Leaderboard logic
-const leaderboardContainer = document.getElementById('leaderboard-container');
-const leaderboardHandle = document.getElementById('leaderboard-handle');
-const leaderboardTable = document.getElementById('leaderboard').getElementsByTagName('tbody')[0];
+let leaderboardContainer;
+let leaderboardHandle;
+let leaderboardTable;
 let sortBy = 'score'; // Default sorting by score
 let sortOrder = 'asc'; // Default sorting order ascending
 
-// Ensure the handle is always visible
-function updateHandlePosition() {
-    if (leaderboardContainer.style.left === '0px') {
-        leaderboardHandle.style.left = '300px';
-    } else {
-        leaderboardHandle.style.left = '0px';
+
+export function initializeLeaderboard() {
+    // Leaderboard logic
+    leaderboardContainer = document.getElementById('leaderboard-container');
+    leaderboardHandle = document.getElementById('leaderboard-handle');
+    leaderboardTable = document.getElementById('leaderboard').getElementsByTagName('tbody')[0];
+
+    // Ensure the handle is always visible
+    function updateHandlePosition() {
+        if (leaderboardContainer.style.left === '0px') {
+            leaderboardHandle.style.left = '300px';
+        } else {
+            leaderboardHandle.style.left = '0px';
+        }
     }
+
+    leaderboardHandle.addEventListener('click', () => {
+        if (leaderboardContainer.style.left === '0px') {
+            leaderboardContainer.style.left = '-300px';
+        } else {
+            leaderboardContainer.style.left = '0px';
+        }
+        updateHandlePosition();
+    });
+
+    // Initialize the leaderboard position
+    leaderboardContainer.style.left = '-300px';
+    updateHandlePosition(); // Call this initially to set the correct position
+
+    // Update handle position on window resize
+    window.addEventListener('resize', updateHandlePosition);
+
+    // MutationObserver to watch for changes in leaderboardContainer's style
+    const observer = new MutationObserver(updateHandlePosition);
+    observer.observe(leaderboardContainer, {attributes: true, attributeFilter: ['style']});
+
+    document.getElementById('score-header').addEventListener('click', () => {
+        sortBy = 'score';
+        sortOrder = sortOrder === 'asc' ? 'desc' : 'asc';
+        updateLeaderboard();
+    });
+
+    document.getElementById('tph-header').addEventListener('click', () => {
+        sortBy = 'tph';
+        sortOrder = sortOrder === 'asc' ? 'desc' : 'asc';
+        updateLeaderboard();
+    });
 }
-
-leaderboardHandle.addEventListener('click', () => {
-    if (leaderboardContainer.style.left === '0px') {
-        leaderboardContainer.style.left = '-300px';
-    } else {
-        leaderboardContainer.style.left = '0px';
-    }
-    updateHandlePosition();
-});
-
-// Initialize the leaderboard position
-leaderboardContainer.style.left = '-300px';
-updateHandlePosition(); // Call this initially to set the correct position
-
-// Update handle position on window resize
-window.addEventListener('resize', updateHandlePosition);
-
-// MutationObserver to watch for changes in leaderboardContainer's style
-const observer = new MutationObserver(updateHandlePosition);
-observer.observe(leaderboardContainer, {attributes: true, attributeFilter: ['style']});
-
-document.getElementById('score-header').addEventListener('click', () => {
-    sortBy = 'score';
-    sortOrder = sortOrder === 'asc' ? 'desc' : 'asc';
-    updateLeaderboard();
-});
-
-document.getElementById('tph-header').addEventListener('click', () => {
-    sortBy = 'tph';
-    sortOrder = sortOrder === 'asc' ? 'desc' : 'asc';
-    updateLeaderboard();
-});
 
 export function updateLeaderboard() {
     const visiblePlayers = getVisiblePlayers(getSortedPlayers(sortBy));

--- a/public/leaderboard.mjs
+++ b/public/leaderboard.mjs
@@ -1,4 +1,4 @@
-import {gameState, getVisibleArea} from './game_state.mjs';
+import {gameState} from './game_state.mjs';
 import {log} from "./utils.mjs";
 import {safeSend} from './net/websocket.mjs';
 
@@ -65,7 +65,7 @@ export function updateLeaderboard() {
         const row = leaderboardTable.insertRow();
         row.insertCell(0).innerText = index + 1; // Rank
         const nameCell = row.insertCell(1);
-        const playerName = gameState.players[player.id].name || 'Anonymous';
+        const playerName = player.name || 'Anonymous';
         nameCell.innerHTML = `
             <span class="player-name">${playerName}</span>
             ${player.id === gameState.player_id ? '<span class="edit-name">✎</span>' : ''}
@@ -98,42 +98,10 @@ function getSortedPlayers(sortBy) {
 }
 
 function getVisiblePlayers(players) {
-    const visiblePlayers = new Set();
-    const currentPlayer = gameState.players[gameState.player_id];
-    const currentPlayerIndex = players.findIndex(player => player.id === currentPlayer.id);
-
-    // Add players above and below the current player
-    if (currentPlayerIndex > 0) {
-        visiblePlayers.add(players[currentPlayerIndex - 1]);
-    }
-    if (currentPlayerIndex < players.length - 1) {
-        visiblePlayers.add(players[currentPlayerIndex + 1]);
-    }
-
-    // Add top player
-    visiblePlayers.add(players[0]);
-
-    // Add current player
-    visiblePlayers.add(currentPlayer);
-
-    // Add players visible in the area
-    const visibleArea = getVisibleArea();
-    players.forEach(player => {
-        if (isPlayerVisible(player, visibleArea)) {
-            visiblePlayers.add(player);
-        }
-    });
-
-    return Array.from(visiblePlayers);
+    return players;  // Return all players for now
 }
 
-function isPlayerVisible(player, visibleArea) {
-    return Object.values(gameState.tiles).some(tile => {
-        return tile.player_id === player.id &&
-            tile.x >= visibleArea[0][0] && tile.x <= visibleArea[1][0] &&
-            tile.y >= visibleArea[0][1] && tile.y <= visibleArea[1][1];
-    });
-}
+// This function is not needed for now
 
 function formatTime(joinTime) {
     const totalSeconds = Math.floor((new Date() - joinTime) / 1000);

--- a/public/leaderboard.mjs
+++ b/public/leaderboard.mjs
@@ -91,27 +91,33 @@ function getSortedPlayers(sortBy) {
 }
 
 function getVisiblePlayers(players) {
-    const visiblePlayers = [];
+    const visiblePlayers = new Set();
     const currentPlayer = gameState.players[gameState.player_id];
     const currentPlayerIndex = players.findIndex(player => player.id === currentPlayer.id);
 
+    // Add players above and below the current player
     if (currentPlayerIndex > 0) {
-        visiblePlayers.push(players[currentPlayerIndex - 1]); // Player above
+        visiblePlayers.add(players[currentPlayerIndex - 1]);
     }
-    visiblePlayers.push(currentPlayer); // Current player
     if (currentPlayerIndex < players.length - 1) {
-        visiblePlayers.push(players[currentPlayerIndex + 1]); // Player below
+        visiblePlayers.add(players[currentPlayerIndex + 1]);
     }
-    visiblePlayers.push(players[0]); // Top player
 
+    // Add top player
+    visiblePlayers.add(players[0]);
+
+    // Add current player
+    visiblePlayers.add(currentPlayer);
+
+    // Add players visible in the area
     const visibleArea = getVisibleArea();
     players.forEach(player => {
-        if (player.id !== currentPlayer.id && isPlayerVisible(player, visibleArea)) {
-            visiblePlayers.push(player);
+        if (isPlayerVisible(player, visibleArea)) {
+            visiblePlayers.add(player);
         }
     });
 
-    return visiblePlayers;
+    return Array.from(visiblePlayers);
 }
 
 function isPlayerVisible(player, visibleArea) {

--- a/public/leaderboard.mjs
+++ b/public/leaderboard.mjs
@@ -98,10 +98,42 @@ function getSortedPlayers(sortBy) {
 }
 
 function getVisiblePlayers(players) {
-    return players;  // Return all players for now
+    const visiblePlayers = new Set();
+    const currentPlayer = gameState.players[gameState.player_id];
+    const currentPlayerIndex = players.findIndex(player => player.id === currentPlayer.id);
+
+    // Add players above and below the current player
+    if (currentPlayerIndex > 0) {
+        visiblePlayers.add(players[currentPlayerIndex - 1]);
+    }
+    if (currentPlayerIndex < players.length - 1) {
+        visiblePlayers.add(players[currentPlayerIndex + 1]);
+    }
+
+    // Add top player
+    visiblePlayers.add(players[0]);
+
+    // Add current player
+    visiblePlayers.add(currentPlayer);
+
+    // Add players visible in the area
+    const visibleArea = getVisibleArea();
+    players.forEach(player => {
+        if (isPlayerVisible(player, visibleArea)) {
+            visiblePlayers.add(player);
+        }
+    });
+
+    return Array.from(visiblePlayers);
 }
 
-// This function is not needed for now
+function isPlayerVisible(player, visibleArea) {
+    return Object.values(gameState.tiles).some(tile => {
+        return tile.player_id === player.id &&
+            tile.x >= visibleArea[0][0] && tile.x <= visibleArea[1][0] &&
+            tile.y >= visibleArea[0][1] && tile.y <= visibleArea[1][1];
+    });
+}
 
 function formatTime(joinTime) {
     const totalSeconds = Math.floor((new Date() - joinTime) / 1000);

--- a/public/leaderboard.mjs
+++ b/public/leaderboard.mjs
@@ -97,34 +97,35 @@ function getSortedPlayers(sortBy) {
     return players;
 }
 
-function getVisiblePlayers(players) {
+function getVisiblePlayers(sortedPlayers) {
+    if (sortedPlayers.length < 10) return sortedPlayers;
     const visiblePlayers = new Set();
     const currentPlayer = gameState.players[gameState.player_id];
-    const currentPlayerIndex = players.findIndex(player => player.id === currentPlayer.id);
+    const currentPlayerIndex = sortedPlayers.findIndex(player => player.id === currentPlayer.id);
 
     // Add players above and below the current player
     if (currentPlayerIndex > 0) {
-        visiblePlayers.add(players[currentPlayerIndex - 1]);
+        visiblePlayers.add(sortedPlayers[currentPlayerIndex - 1]);
     }
-    if (currentPlayerIndex < players.length - 1) {
-        visiblePlayers.add(players[currentPlayerIndex + 1]);
+    if (currentPlayerIndex < sortedPlayers.length - 1) {
+        visiblePlayers.add(sortedPlayers[currentPlayerIndex + 1]);
     }
 
     // Add top player
-    visiblePlayers.add(players[0]);
+    visiblePlayers.add(sortedPlayers[0]);
 
     // Add current player
     visiblePlayers.add(currentPlayer);
 
     // Add players visible in the area
     const visibleArea = getVisibleArea();
-    players.forEach(player => {
+    sortedPlayers.forEach(player => {
         if (isPlayerVisible(player, visibleArea)) {
             visiblePlayers.add(player);
         }
     });
 
-    return Array.from(visiblePlayers);
+    return sortedPlayers.filter(player => visiblePlayers.has(player));
 }
 
 function isPlayerVisible(player, visibleArea) {

--- a/public/main.mjs
+++ b/public/main.mjs
@@ -6,6 +6,7 @@ import {initializeUiEventListeners} from './ui/uiEventHandlers.mjs';
 import {initializeRenderer} from './ui/gameRenderer.mjs';
 import {initializeWebSocket} from './net/websocket.mjs';
 import {getJoinAction, registerResponseHandlers} from "./net/serverProtocol.mjs";
+import {initializeLeaderboard} from "./leaderboard.mjs";
 
 const {canvas, ctx} = initializeCanvas();
 initializeRenderer(ctx);
@@ -16,6 +17,7 @@ const joinAction = getJoinAction(horizontalTiles, verticalTiles, gameState.token
 initializeWebSocket(joinAction);
 registerResponseHandlers();
 initializeUiEventListeners(canvas);
+initializeLeaderboard();
 
 // FOR DEBUGGING:
 window.getVisibleArea = getVisibleArea;

--- a/public/tests/leaderboard.test.js
+++ b/public/tests/leaderboard.test.js
@@ -1,0 +1,86 @@
+// See https://medium.com/dailyjs/running-mocha-tests-as-native-es6-modules-in-a-browser-882373f2ecb0
+
+import { gameState } from '../game_state.mjs';
+import { initializeLeaderboard, updateLeaderboard } from '../leaderboard.mjs';
+
+const { assert } = chai;
+
+describe('Leaderboard Tests', () => {
+  let testContainer;
+
+  before(() => {
+    // Create a non-visible test container
+    testContainer = document.createElement('div');
+    testContainer.style.position = 'absolute';
+    testContainer.style.top = '-9999px';
+    testContainer.style.left = '-9999px';
+    document.body.appendChild(testContainer);
+  });
+
+  beforeEach(() => {
+    // Reset gameState before each test
+    gameState.player_id = 1;
+    gameState.players = {};
+    gameState.tiles = {};
+
+    // Clear and set up the test container
+    testContainer.innerHTML = `
+      <div id="leaderboard-container">
+        <div id="leaderboard-handle">☰</div>
+        <table id="leaderboard">
+          <thead>
+            <tr>
+              <th id="rank-header"></th>
+              <th id="name-header">Name</th>
+              <th id="score-header">Score</th>
+              <th id="time-header">Time</th>
+              <th id="tph-header">TPH</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    `;
+
+    // Mock the log function
+    window.log = console.log;
+
+    // Mock the getVisibleArea function
+    window.getVisibleArea = () => [[0, 0], [10, 10]];
+
+    // Mock the isPlayerVisible function (assume all players are visible)
+    window.isPlayerVisible = () => true;
+
+    initializeLeaderboard();
+  });
+
+  after(() => {
+    // Remove the test container after all tests
+    document.body.removeChild(testContainer);
+  });
+
+  it('should not show duplicate entry for current player', () => {
+    // Set up the game state
+    gameState.player_id = 1;
+    gameState.players = {
+      1: { id: 1, name: 'Player 1', score: 100, join_time: new Date(), color: '#ff0000' },
+      2: { id: 2, name: 'Player 2', score: 200, join_time: new Date(), color: '#00ff00' },
+      3: { id: 3, name: 'Player 3', score: 300, join_time: new Date(), color: '#0000ff' },
+    };
+
+    // Update the leaderboard
+    updateLeaderboard();
+
+    // Get the leaderboard rows
+    const leaderboardRows = document.querySelectorAll('#leaderboard tbody tr');
+
+    // Check that there are exactly 3 rows (one for each player)
+    assert.strictEqual(leaderboardRows.length, 3, 'Leaderboard should have exactly 3 rows');
+
+    // Check that the current player (Player 1) appears only once
+    const player1Entries = Array.from(leaderboardRows).filter(row => 
+      row.cells[1].textContent.includes('Player 1')
+    );
+    assert.strictEqual(player1Entries.length, 1, 'Current player should appear only once in the leaderboard');
+  });
+});

--- a/public/tests/run-tests.html
+++ b/public/tests/run-tests.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Leaderboard Tests</title>
+    <script src="https://unpkg.com/mocha/mocha.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/mocha/mocha.css" />
+</head>
+<body>
+    <div id="mocha"></div>
+
+    <script type="module" src="setup.js"></script>
+    <script type="module" src="run.js"></script>
+</body>
+</html>

--- a/public/tests/run.js
+++ b/public/tests/run.js
@@ -1,0 +1,3 @@
+import './leaderboard.test.js';
+
+mocha.run();

--- a/public/tests/setup.js
+++ b/public/tests/setup.js
@@ -1,0 +1,3 @@
+import 'https://unpkg.com/chai@4.3.4/chai.js';
+
+mocha.setup('bdd');


### PR DESCRIPTION
Prevent duplicate player entries in the leaderboard by using a `Set` to store unique visible players.

Fixes #24.

Also removes leaderboard filtering – in v0.2.0 the leaderboard only showed, according to the current sorting by Score or TPH:
- the number one player
- all players with uncovered tiles currently visible
- player just above the current player by rank
- player just below the current player by rank

Since the feature wasn't really properly finished, the whole leaderboard is now currenly shown.
