### PR TITLE
Upload binary to production server in PRs

### DIFF
--- a/.github/scripts/update_version.py
+++ b/.github/scripts/update_version.py
@@ -3,13 +3,14 @@ import re
 import zipfile
 from datetime import datetime
 
+
 def update_version(file_path, new_version):
     with open(file_path, 'r', encoding='utf-8') as file:
         content = file.read()
-    
+
     # Pattern to match internal URLs in href and src attributes
     pattern = r'(href|src)="(?!http[s]?://|//|#)([^"]+)(\?v=[^"]*)?"'
-    
+
     def replace_version(match):
         attr, path, _ = match.groups()
         return f'{attr}="{path}?v={new_version}"'
@@ -19,6 +20,7 @@ def update_version(file_path, new_version):
     with open(file_path, 'w', encoding='utf-8') as file:
         file.write(updated_content)
 
+
 def process_directory(directory, new_version):
     for root, _, files in os.walk(directory):
         for file in files:
@@ -27,6 +29,7 @@ def process_directory(directory, new_version):
                 print(f"Processing: {file_path}")
                 update_version(file_path, new_version)
 
+
 def create_zip_archive(source_dir, output_filename):
     with zipfile.ZipFile(output_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
         for root, _, files in os.walk(source_dir):
@@ -34,6 +37,7 @@ def create_zip_archive(source_dir, output_filename):
                 file_path = os.path.join(root, file)
                 arcname = os.path.relpath(file_path, source_dir)
                 zipf.write(file_path, arcname)
+
 
 # Generate new version
 new_version = datetime.now().strftime("%Y%m%d%H%M%S")

--- a/.github/scripts/update_version.py
+++ b/.github/scripts/update_version.py
@@ -1,12 +1,11 @@
 import os
 import re
+import zipfile
 from datetime import datetime
 
-def update_version(file_path):
+def update_version(file_path, new_version):
     with open(file_path, 'r', encoding='utf-8') as file:
         content = file.read()
-
-    new_version = datetime.now().strftime("%Y%m%d%H%M%S")
     
     # Pattern to match internal URLs in href and src attributes
     pattern = r'(href|src)="(?!http[s]?://|//|#)([^"]+)(\?v=[^"]*)?"'
@@ -20,16 +19,33 @@ def update_version(file_path):
     with open(file_path, 'w', encoding='utf-8') as file:
         file.write(updated_content)
 
-def process_directory(directory):
+def process_directory(directory, new_version):
     for root, _, files in os.walk(directory):
         for file in files:
             if file.endswith(('.html', '.css', '.mjs')):
                 file_path = os.path.join(root, file)
                 print(f"Processing: {file_path}")
-                update_version(file_path)
+                update_version(file_path, new_version)
+
+def create_zip_archive(source_dir, output_filename):
+    with zipfile.ZipFile(output_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
+        for root, _, files in os.walk(source_dir):
+            for file in files:
+                file_path = os.path.join(root, file)
+                arcname = os.path.relpath(file_path, source_dir)
+                zipf.write(file_path, arcname)
+
+# Generate new version
+new_version = datetime.now().strftime("%Y%m%d%H%M%S")
 
 # Specify the root directory to start from
 root_directory = 'public'
-process_directory(root_directory)
+process_directory(root_directory, new_version)
 
 print("Version update complete.")
+
+# Create static content archive
+archive_name = '../mmoinsweeper-static-content.zip'
+create_zip_archive(root_directory, archive_name)
+
+print(f"Static content archive created: {archive_name}")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,11 +78,12 @@ jobs:
         
       - name: Upload to production server
         env:
-          PROD_HOST: ${{ secrets.PROD_HOST }}
-          PROD_SERVICE_USER: ${{ secrets.PROD_SERVICE_USER }}
-          PROD_SERVICE_USER_SSH_KEY: ${{ secrets.PROD_SERVICE_USER_SSH_KEY }}
+          HOST: ${{ secrets.PROD_HOST }}
+          USER: ${{ secrets.PROD_SERVICE_USER }}
+          KEY: ${{ secrets.PROD_SERVICE_USER_SSH_KEY }}
+          BRANCH: ${{ steps.branch_name.outputs.branch }}
         run: |
-          echo "$PROD_SERVICE_USER_SSH_KEY" > ssh_key
+          echo "$KEY" > ssh_key
           chmod 600 ssh_key
-          scp -i ssh_key -o StrictHostKeyChecking=no ./target/release/mmoinsweeper $PROD_SERVICE_USER@$PROD_HOST:~/mmoinsweeper-${{ steps.branch_name.outputs.branch }}
+          scp -i ssh_key -o StrictHostKeyChecking=no ./target/release/mmoinsweeper $USER@$HOST:~/mmoinsweeper-$BRANCH
           rm ssh_key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,17 @@
-name: Release
+name: CI/CD
 
 on:
   push:
     tags:
       - 'v*'
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   release:
     name: Build and Release
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
     steps:
@@ -56,3 +59,34 @@ jobs:
           make_latest: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  pr_build_and_upload:
+    name: PR Build and Upload
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          
+      - name: Build
+        run: cargo build --release
+        
+      - name: Get branch name
+        id: branch_name
+        run: echo "::set-output name=branch::${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+        
+      - name: Upload to production server
+        env:
+          PROD_HOST: ${{ secrets.PROD_HOST }}
+          PROD_SERVICE_USER: ${{ secrets.PROD_SERVICE_USER }}
+          PROD_SERVICE_USER_SSH_KEY: ${{ secrets.PROD_SERVICE_USER_SSH_KEY }}
+        run: |
+          echo "$PROD_SERVICE_USER_SSH_KEY" > ssh_key
+          chmod 600 ssh_key
+          scp -i ssh_key -o StrictHostKeyChecking=no ./target/release/mmoinsweeper $PROD_SERVICE_USER@$PROD_HOST:~/mmoinsweeper-${{ steps.branch_name.outputs.branch }}
+          rm ssh_key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,13 +37,9 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Update version in static content
+      - name: Update version in static content and create archive
         run: |
           python .github/scripts/update_version.py
-
-      - name: Create static content archive
-        run: |
-          cd public && zip -r ../mmoinsweeper-static-content.zip .
 
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - 'v*'
   pull_request:
-    types: [opened, synchronize]
+    types: [ opened, synchronize ]
 
 jobs:
   release:
@@ -16,16 +16,16 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
-          
+
       - name: Build
         run: cargo build --release
-        
+
       - name: Generate Changelog
         run: |
           echo "# Changelog" > ${{ github.workspace }}-CHANGELOG.md
@@ -62,20 +62,20 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
-          
+
       - name: Build
         run: cargo build --release
-        
+
       - name: Get branch name
         id: branch_name
         run: echo "::set-output name=branch::${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
-        
+
       - name: Upload to production server
         env:
           HOST: ${{ secrets.PROD_HOST }}


### PR DESCRIPTION
There will be test instances for PRs on the production server. Raw static data for the frontend an be easily fetched by the Ansible deployment playbook from GitHub, but for the compiled Rust binary I don't want to create a GitHub Release for each commit in each PR. So I'll just have the GitHub workflow upload the binary to the server ready to be deployed.

This relates to akaihola/mmoinsweeper.top#1.