### PR TITLE
Speed up compilation using cargo caching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: CI/CD
+name: Release
 
 on:
   push:
@@ -22,6 +22,11 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Build
         run: cargo build --release
@@ -68,6 +73,11 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Build
         run: cargo build --release

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -21,6 +21,11 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+          components: rustfmt, clippy
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Fixes #22.

See e.g. [How I speeded up my Rust builds on GitHub ~30 times](https://ectobit.com/blog/speed-up-github-actions-rust-pipelines/) (from Ectobit).