### PR TITLE
Replace unknown token

### DIFF
--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -200,7 +200,7 @@ impl GameState {
             if let Some(existing_player) = self.players.values().find(|p| p.token == token) {
                 (token, existing_player.name.clone())
             } else {
-                (token, format!("Player {}", player_id))
+                (uuid::Uuid::new_v4().to_string(), format!("Player {}", player_id))
             }
         } else {
             (uuid::Uuid::new_v4().to_string(), format!("Player {}", player_id))


### PR DESCRIPTION
This could happen e.g. after server restart. The client offers the old token it saved in local storage hoping to get the old player name. But the server has forgotten the token and needs to create a new one.

Also now include a reason or token reissue in the server response.