### PR TITLE
Player color now determined by player ID

### DIFF
--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use warp::ws::Message;
 
+use crate::player_color::get_player_color_hex;
+
 pub type TileCoordinate = i64;
 pub type Position = (TileCoordinate, TileCoordinate);
 pub type PositionString = String;
@@ -38,7 +40,6 @@ pub struct DbPlayer {
     pub token: String,
     pub join_time: ServerTime,
     pub game_over: bool,
-    pub color: String,
     pub score: u32,
     pub sender: Option<mpsc::UnboundedSender<Message>>,
     pub visible_area: Area,
@@ -235,7 +236,6 @@ impl GameState {
             DbPlayer {
                 join_time: seconds_since(self.epoch),
                 token: token.clone(),
-                color: format!("#{:06x}", rand::thread_rng().gen_range(0..0xFFFFFF)),
                 score: 0,
                 game_over: false,
                 sender: None,
@@ -372,7 +372,7 @@ impl GameState {
                         id,
                         ClientPlayer {
                             join_time: self.epoch + player.join_time,
-                            color: player.color.clone(),
+                            color: get_player_color_hex(id),
                             score: player.score,
                             name: player.name.clone(),
                         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use game_state::{GameState, PlayerAction};
 use crate::game_state::GameStateResponse;
 
 mod game_state;
+mod player_color;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/src/player_color.rs
+++ b/src/player_color.rs
@@ -1,0 +1,16 @@
+const M1: u64 = 54787;
+const M2: u64 = 25867;
+const M3: u64 = 9337;
+
+fn get_nth_color(n: u32) -> (u16, u16, u16) {
+    let red = ((M1 * n as u64) % 65536) as u16;
+    let green = ((M2 * n as u64) % 65536) as u16;
+    let blue = ((M3 * n as u64) % 65536) as u16;
+
+    (red, green, blue)
+}
+
+pub fn get_player_color_hex(player_id: u32) -> String {
+    let (red, green, blue) = get_nth_color(player_id);
+    format!("#{:02X}{:02X}{:02X}", red / 256, green / 256, blue / 256)
+}


### PR DESCRIPTION
Algorithm favors colors easily distinguishable from each other for nearby player IDs. It walks through the whole 16-bit RGB color space before repeating a color.